### PR TITLE
copy finally fixed

### DIFF
--- a/biostar/engine/auth.py
+++ b/biostar/engine/auth.py
@@ -87,8 +87,6 @@ def copy(request, instance, board):
 
     request.session.update({settings.CLIPBOARD_NAME: clipboard})
 
-    request.session.save()
-
     messages.success(request, f"Copied items, there are {len(board_items)} in clipboard.")
 
     return board_items

--- a/biostar/engine/decorators.py
+++ b/biostar/engine/decorators.py
@@ -125,22 +125,3 @@ class write_access:
             return redirect(target)
 
         return _wrapped_view
-
-
-def check_sessions(func):
-
-    @wraps(func, assigned=available_attrs(func))
-    def __wrapper(request,  *args, **kwargs):
-        # Sessions storage and retrieval works
-        print(request.session.get("test"), "HAS test in decorator")
-
-        print(request.session._session_cache, "SESSION CACHE in decoratrs")
-
-        if request.session.test_cookie_worked():
-            request.session.delete_test_cookie()
-            return func(request, *args, **kwargs)
-
-        messages.error(request, "Sessions storage and retrieval is not working correctly.")
-        return func(request, *args, **kwargs)
-
-    return __wrapper

--- a/biostar/engine/templatetags/engine_tags.py
+++ b/biostar/engine/templatetags/engine_tags.py
@@ -126,11 +126,6 @@ def paste(context, project, current=""):
 
     clipboard_count = len(board) if request.user.is_authenticated else 0
 
-    print(clipboard, current)
-
-    print(request.session.get("test"), "HAS test in tags")
-    print(request.session._session_cache, "SESSION CACHE in tags")
-
     extra_context = dict(clipboard_count=clipboard_count, project=project, current=current, board=board, context=context)
     context.update(extra_context)
     return context

--- a/biostar/engine/views.py
+++ b/biostar/engine/views.py
@@ -523,13 +523,11 @@ def recipe_code_download(request, uid):
     recipe = Analysis.objects.filter(uid=uid).first()
 
     # Trigger file download with name of the recipe
-    filename = "_".join(recipe.name.split()) + ".txt"
+    filename = "_".join(recipe.name.split()) + ".sh"
 
     response = HttpResponse(recipe.template, content_type='text/plain')
     response['Content-Disposition'] = f'attachment; filename={filename}'
 
-    # sendfile(request, file_path, attachment=True, attachment_filename=fname, mimetype=mimetype)
-    #print(recipe.template, filename)
     return response
 
 

--- a/biostar/engine/views.py
+++ b/biostar/engine/views.py
@@ -19,7 +19,7 @@ from biostar.forum import views as forum_views
 from biostar.forum.models import Post
 from biostar.utils.shortcuts import reverse
 from . import tasks, auth, forms, const
-from .decorators import read_access, write_access, check_sessions
+from .decorators import read_access, write_access
 from .models import (Project, Data, Analysis, Job, Access)
 
 # The current directory

--- a/biostar/engine/views.py
+++ b/biostar/engine/views.py
@@ -87,7 +87,6 @@ def clear_clipboard(request, uid):
     if clipboard.get(board):
         clipboard[board] = []
         request.session.update({settings.CLIPBOARD_NAME: clipboard})
-        request.session.save()
 
     return redirect(next_url)
 
@@ -387,7 +386,6 @@ def recipe_paste(request, uid):
     # Reset the session.
     clipboard[const.RECIPE_CLIPBOARD] = []
     request.session.update({settings.CLIPBOARD_NAME: clipboard})
-    request.session.save()
 
     # Notification after paste.
     messages.success(request, mark_safe(f"Pasted <b>{len(new_recipes)} recipes</b>  in clipboard"))

--- a/biostar/engine/views.py
+++ b/biostar/engine/views.py
@@ -336,9 +336,6 @@ def recipe_copy(request, uid):
     recipe = Analysis.objects.get_all(uid=uid).first()
     next_url = request.GET.get("next", reverse("recipe_list", kwargs=dict(uid=recipe.project.uid)))
 
-    # Set test cookies
-    request.session.set_test_cookie()
-
     auth.copy(request=request, instance=recipe, board=const.RECIPE_CLIPBOARD)
 
     return redirect(next_url)
@@ -355,7 +352,6 @@ def job_copy(request, uid):
 
 
 @write_access(type=Project, fallback_view="recipe_list")
-#@check_sessions
 def recipe_paste(request, uid):
     """
     Pastes recipes from clipboard as a new recipes.

--- a/biostar/settings.py
+++ b/biostar/settings.py
@@ -251,7 +251,7 @@ SESSION_KEY = "session"
 
 COUNT_INTERVAL_WEEKS = 10000
 
-SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
 SESSION_SAVE_EVERY_REQUEST = True
 #SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 

--- a/conf/devel/devel_uwsgi.ini
+++ b/conf/devel/devel_uwsgi.ini
@@ -1,7 +1,8 @@
 [uwsgi]
 http-socket = :8000
 module = conf.devel.devel_wsgi
-processes = 10
+processes = 2
+threads = 10
 stopsignal=QUIT
 master=true
 


### PR DESCRIPTION
- backends.db is the correct option and not backends.cached_db, they both use the database for storage but the latter reads from the browser cache instead of the database. 
- backends.db is mentioned in passing in the docs because it is the default option.